### PR TITLE
Choose product based on real executable

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1006,6 +1006,10 @@
 			"Rev": "772f5c38e468398c4511514f4f6aa9a4185bc0a0"
 		},
 		{
+			"ImportPath": "github.com/kardianos/osext",
+			"Rev": "6e7f843663477789fac7c02def0d0909e969b4e5"
+		},
+		{
 			"ImportPath": "github.com/kr/pty",
 			"Comment": "release.r56-25-g05017fc",
 			"Rev": "05017fcccf23c823bfdea560dcc958a136e54fb7"

--- a/Godeps/_workspace/src/github.com/kardianos/osext/LICENSE
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Godeps/_workspace/src/github.com/kardianos/osext/README.md
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/README.md
@@ -1,0 +1,16 @@
+### Extensions to the "os" package.
+
+## Find the current Executable and ExecutableFolder.
+
+There is sometimes utility in finding the current executable file
+that is running. This can be used for upgrading the current executable
+or finding resources located relative to the executable file. Both
+working directory and the os.Args[0] value are arbitrary and cannot
+be relied on; os.Args[0] can be "faked".
+
+Multi-platform and supports:
+ * Linux
+ * OS X
+ * Windows
+ * Plan 9
+ * BSDs.

--- a/Godeps/_workspace/src/github.com/kardianos/osext/osext.go
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/osext.go
@@ -1,0 +1,27 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Extensions to the standard "os" package.
+package osext // import "github.com/kardianos/osext"
+
+import "path/filepath"
+
+// Executable returns an absolute path that can be used to
+// re-invoke the current program.
+// It may not be valid after the current program exits.
+func Executable() (string, error) {
+	p, err := executable()
+	return filepath.Clean(p), err
+}
+
+// Returns same path as Executable, returns just the folder
+// path. Excludes the executable name and any trailing slash.
+func ExecutableFolder() (string, error) {
+	p, err := Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(p), nil
+}

--- a/Godeps/_workspace/src/github.com/kardianos/osext/osext_plan9.go
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/osext_plan9.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func executable() (string, error) {
+	f, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/text")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return syscall.Fd2path(int(f.Fd()))
+}

--- a/Godeps/_workspace/src/github.com/kardianos/osext/osext_procfs.go
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/osext_procfs.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux netbsd openbsd solaris dragonfly
+
+package osext
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func executable() (string, error) {
+	switch runtime.GOOS {
+	case "linux":
+		const deletedTag = " (deleted)"
+		execpath, err := os.Readlink("/proc/self/exe")
+		if err != nil {
+			return execpath, err
+		}
+		execpath = strings.TrimSuffix(execpath, deletedTag)
+		execpath = strings.TrimPrefix(execpath, deletedTag)
+		return execpath, nil
+	case "netbsd":
+		return os.Readlink("/proc/curproc/exe")
+	case "openbsd", "dragonfly":
+		return os.Readlink("/proc/curproc/file")
+	case "solaris":
+		return os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", os.Getpid()))
+	}
+	return "", errors.New("ExecPath not implemented for " + runtime.GOOS)
+}

--- a/Godeps/_workspace/src/github.com/kardianos/osext/osext_sysctl.go
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/osext_sysctl.go
@@ -1,0 +1,79 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin freebsd
+
+package osext
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var initCwd, initCwdErr = os.Getwd()
+
+func executable() (string, error) {
+	var mib [4]int32
+	switch runtime.GOOS {
+	case "freebsd":
+		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
+	case "darwin":
+		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	}
+
+	n := uintptr(0)
+	// Get length.
+	_, _, errNum := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, errNum = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	for i, v := range buf {
+		if v == 0 {
+			buf = buf[:i]
+			break
+		}
+	}
+	var err error
+	execPath := string(buf)
+	// execPath will not be empty due to above checks.
+	// Try to get the absolute path if the execPath is not rooted.
+	if execPath[0] != '/' {
+		execPath, err = getAbs(execPath)
+		if err != nil {
+			return execPath, err
+		}
+	}
+	// For darwin KERN_PROCARGS may return the path to a symlink rather than the
+	// actual executable.
+	if runtime.GOOS == "darwin" {
+		if execPath, err = filepath.EvalSymlinks(execPath); err != nil {
+			return execPath, err
+		}
+	}
+	return execPath, nil
+}
+
+func getAbs(execPath string) (string, error) {
+	if initCwdErr != nil {
+		return execPath, initCwdErr
+	}
+	// The execPath may begin with a "../" or a "./" so clean it first.
+	// Join the two paths, trailing and starting slashes undetermined, so use
+	// the generic Join function.
+	return filepath.Join(initCwd, filepath.Clean(execPath)), nil
+}

--- a/Godeps/_workspace/src/github.com/kardianos/osext/osext_test.go
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/osext_test.go
@@ -1,0 +1,203 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin linux freebsd netbsd windows
+
+package osext
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	executableEnvVar = "OSTEST_OUTPUT_EXECUTABLE"
+
+	executableEnvValueMatch  = "match"
+	executableEnvValueDelete = "delete"
+)
+
+func TestPrintExecutable(t *testing.T) {
+	ef, err := Executable()
+	if err != nil {
+		t.Fatalf("Executable failed: %v", err)
+	}
+	t.Log("Executable:", ef)
+}
+func TestPrintExecutableFolder(t *testing.T) {
+	ef, err := ExecutableFolder()
+	if err != nil {
+		t.Fatalf("ExecutableFolder failed: %v", err)
+	}
+	t.Log("Executable Folder:", ef)
+}
+func TestExecutableFolder(t *testing.T) {
+	ef, err := ExecutableFolder()
+	if err != nil {
+		t.Fatalf("ExecutableFolder failed: %v", err)
+	}
+	if ef[len(ef)-1] == filepath.Separator {
+		t.Fatal("ExecutableFolder ends with a trailing slash.")
+	}
+}
+func TestExecutableMatch(t *testing.T) {
+	ep, err := Executable()
+	if err != nil {
+		t.Fatalf("Executable failed: %v", err)
+	}
+
+	// fullpath to be of the form "dir/prog".
+	dir := filepath.Dir(filepath.Dir(ep))
+	fullpath, err := filepath.Rel(dir, ep)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	// Make child start with a relative program path.
+	// Alter argv[0] for child to verify getting real path without argv[0].
+	cmd := &exec.Cmd{
+		Dir:  dir,
+		Path: fullpath,
+		Env:  []string{fmt.Sprintf("%s=%s", executableEnvVar, executableEnvValueMatch)},
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("exec(self) failed: %v", err)
+	}
+	outs := string(out)
+	if !filepath.IsAbs(outs) {
+		t.Fatalf("Child returned %q, want an absolute path", out)
+	}
+	if !sameFile(outs, ep) {
+		t.Fatalf("Child returned %q, not the same file as %q", out, ep)
+	}
+}
+
+func TestExecutableDelete(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	fpath, err := Executable()
+	if err != nil {
+		t.Fatalf("Executable failed: %v", err)
+	}
+
+	r, w := io.Pipe()
+	stderrBuff := &bytes.Buffer{}
+	stdoutBuff := &bytes.Buffer{}
+	cmd := &exec.Cmd{
+		Path:   fpath,
+		Env:    []string{fmt.Sprintf("%s=%s", executableEnvVar, executableEnvValueDelete)},
+		Stdin:  r,
+		Stderr: stderrBuff,
+		Stdout: stdoutBuff,
+	}
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("exec(self) start failed: %v", err)
+	}
+
+	tempPath := fpath + "_copy"
+	_ = os.Remove(tempPath)
+
+	err = copyFile(tempPath, fpath)
+	if err != nil {
+		t.Fatalf("copy file failed: %v", err)
+	}
+	err = os.Remove(fpath)
+	if err != nil {
+		t.Fatalf("remove running test file failed: %v", err)
+	}
+	err = os.Rename(tempPath, fpath)
+	if err != nil {
+		t.Fatalf("rename copy to previous name failed: %v", err)
+	}
+
+	w.Write([]byte{0})
+	w.Close()
+
+	err = cmd.Wait()
+	if err != nil {
+		t.Fatalf("exec wait failed: %v", err)
+	}
+
+	childPath := stderrBuff.String()
+	if !filepath.IsAbs(childPath) {
+		t.Fatalf("Child returned %q, want an absolute path", childPath)
+	}
+	if !sameFile(childPath, fpath) {
+		t.Fatalf("Child returned %q, not the same file as %q", childPath, fpath)
+	}
+}
+
+func sameFile(fn1, fn2 string) bool {
+	fi1, err := os.Stat(fn1)
+	if err != nil {
+		return false
+	}
+	fi2, err := os.Stat(fn2)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fi1, fi2)
+}
+func copyFile(dest, src string) error {
+	df, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer df.Close()
+
+	sf, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sf.Close()
+
+	_, err = io.Copy(df, sf)
+	return err
+}
+
+func TestMain(m *testing.M) {
+	env := os.Getenv(executableEnvVar)
+	switch env {
+	case "":
+		os.Exit(m.Run())
+	case executableEnvValueMatch:
+		// First chdir to another path.
+		dir := "/"
+		if runtime.GOOS == "windows" {
+			dir = filepath.VolumeName(".")
+		}
+		os.Chdir(dir)
+		if ep, err := Executable(); err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+		} else {
+			fmt.Fprint(os.Stderr, ep)
+		}
+	case executableEnvValueDelete:
+		bb := make([]byte, 1)
+		var err error
+		n, err := os.Stdin.Read(bb)
+		if err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+			os.Exit(2)
+		}
+		if n != 1 {
+			fmt.Fprint(os.Stderr, "ERROR: n != 1, n == ", n)
+			os.Exit(2)
+		}
+		if ep, err := Executable(); err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+		} else {
+			fmt.Fprint(os.Stderr, ep)
+		}
+	}
+	os.Exit(0)
+}

--- a/Godeps/_workspace/src/github.com/kardianos/osext/osext_windows.go
+++ b/Godeps/_workspace/src/github.com/kardianos/osext/osext_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel                = syscall.MustLoadDLL("kernel32.dll")
+	getModuleFileNameProc = kernel.MustFindProc("GetModuleFileNameW")
+)
+
+// GetModuleFileName() with hModule = NULL
+func executable() (exePath string, err error) {
+	return getModuleFileName()
+}
+
+func getModuleFileName() (string, error) {
+	var n uint32
+	b := make([]uint16, syscall.MAX_PATH)
+	size := uint32(len(b))
+
+	r0, _, e1 := getModuleFileNameProc.Call(0, uintptr(unsafe.Pointer(&b[0])), uintptr(size))
+	n = uint32(r0)
+	if n == 0 {
+		return "", e1
+	}
+	return string(utf16.Decode(b[0:n])), nil
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -171,6 +171,23 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 # Begin tests
 #
 
+# create master config as atomic-enterprise just to test it works
+atomic-enterprise start \
+  --write-config=$TEMP_DIR/atomic.local.config \
+  --create-certs=true \
+  --master="${API_SCHEME}://${API_HOST}:${API_PORT}" \
+  --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" \
+  --hostname="${KUBELET_HOST}" \
+  --volume-dir="${VOLUME_DIR}" \
+  --etcd-dir="${ETCD_DATA_DIR}" \
+  --images="${USE_IMAGES}"
+
+# ensure that DisabledFeatures aren't written to config files
+! grep -i '\<disabledFeatures\>' \
+	"${MASTER_CONFIG_DIR}/master-config.yaml" \
+	"$TEMP_DIR/atomic.local.config/master/master-config.yaml" \
+	"${NODE_CONFIG_DIR}/node-config.yaml"
+
 # test client not configured
 [ "$(oc get services 2>&1 | grep 'Error in configuration')" ]
 

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -92,18 +92,10 @@ func CommandFor(basename string) *cobra.Command {
 func NewCommandOpenShift(name string) *cobra.Command {
 	out := os.Stdout
 
-	product := "Origin"
-	switch name {
-	case "openshift":
-		product = "OpenShift"
-	case "atomic-enterprise":
-		product = "Atomic"
-	}
-
 	root := &cobra.Command{
 		Use:   name,
 		Short: "Build, deploy, and manage your cloud applications",
-		Long:  fmt.Sprintf(openshiftLong, name, product),
+		Long:  fmt.Sprintf(openshiftLong, name, cmdutil.GetProductName()),
 		Run:   cmdutil.DefaultSubCommandRun(out),
 	}
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -6,6 +6,12 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
+const (
+	FeatureBuilder    = `Builder`
+	FeatureS2I        = `S2I Builder`
+	FeatureWebConsole = `Web Console`
+)
+
 var (
 	KnownKubernetesAPILevels   = []string{"v1beta1", "v1beta2", "v1beta3", "v1"}
 	KnownOpenShiftAPILevels    = []string{"v1beta1", "v1beta3", "v1"}
@@ -13,6 +19,9 @@ var (
 	DefaultOpenShiftAPILevels  = []string{"v1beta3", "v1"}
 	DeadKubernetesAPILevels    = []string{"v1beta1", "v1beta2"}
 	DeadOpenShiftAPILevels     = []string{"v1beta1"}
+
+	KnownOpenShiftFeatures = []string{FeatureBuilder, FeatureS2I, FeatureWebConsole}
+	AtomicDisabledFeatures = []string{FeatureBuilder, FeatureS2I, FeatureWebConsole}
 )
 
 type ExtendedArguments map[string][]string
@@ -83,6 +92,8 @@ const (
 	ControllersAll = "*"
 )
 
+type FeatureList []string
+
 type MasterConfig struct {
 	api.TypeMeta
 
@@ -106,6 +117,9 @@ type MasterConfig struct {
 	// PauseControllers instructs the master to not automatically start controllers, but instead
 	// to wait until a notification to the server is received before launching them.
 	PauseControllers bool
+
+	// Allow to disable OpenShift components
+	DisabledFeatures FeatureList
 
 	// EtcdStorageConfig contains information about how API resources are
 	// stored in Etcd. These values are only relevant when etcd is the

--- a/pkg/cmd/server/api/types_test.go
+++ b/pkg/cmd/server/api/types_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFeatureListAdd(t *testing.T) {
+	orderedList := []string{FeatureBuilder, FeatureWebConsole, FeatureS2I}
+	fl := FeatureList{}
+	if err := fl.Add(FeatureBuilder); err != nil {
+		t.Fatalf("failed to add feature %q: %v", FeatureBuilder, err)
+	}
+	if len(fl) != 1 {
+		t.Fatalf("feature list shall contain 1 item")
+	}
+	if err := fl.Add(strings.ToUpper(FeatureWebConsole)); err != nil {
+		t.Fatalf("failed to add feature %q: %v", FeatureWebConsole, err)
+	}
+	if len(fl) != 2 {
+		t.Fatalf("feature list shall contain 1 item")
+	}
+	for i := 0; i < 2; i++ {
+		if fl[i] != orderedList[i] {
+			t.Errorf("fl[%d] == %q, but %q is right", i, fl[i], orderedList[i])
+		}
+	}
+	// add already existing
+	if err := fl.Add(FeatureBuilder); err != nil {
+		t.Fatalf("failed to add feature %q: %v", FeatureBuilder, err)
+	}
+	// add unknown
+	if err := fl.Add("unknown"); err == nil {
+		t.Fatalf("adding unknown feature should have failed")
+	}
+	// add multiple at once
+	if err := fl.Add(FeatureWebConsole, FeatureS2I, FeatureBuilder); err != nil {
+		t.Fatalf("failed to add multiple features: %v", err)
+	}
+	if len(fl) != 3 {
+		t.Fatalf("feature list has unexpected length (%d != %d)", len(fl), len(orderedList))
+	}
+	for i := 0; i < 3; i++ {
+		if fl[i] != orderedList[i] {
+			t.Errorf("fl[%d] == %q, but %q is right", i, fl[i], orderedList[i])
+		}
+	}
+}
+
+func TestFeatureListDelete(t *testing.T) {
+	fl := FeatureList(KnownOpenShiftFeatures)
+	// try to delete unknown feature
+	fl.Delete("unknown")
+	if len(fl) != len(KnownOpenShiftFeatures) {
+		t.Fatalf("fl.Delete() unexpectedly modified the list: %d != %d", len(fl), len(KnownOpenShiftFeatures))
+	}
+	fl.Delete(strings.ToUpper(KnownOpenShiftFeatures[1]))
+	if len(fl) != len(KnownOpenShiftFeatures)-1 {
+		t.Fatalf("Delete() should have removed exactly 1 item: %d != %d", len(fl), len(KnownOpenShiftFeatures)-1)
+
+	}
+	flIndex := 0
+	// ensure that the order of items is kept
+	for i := 0; i < len(KnownOpenShiftFeatures); i++ {
+		if i == 1 {
+			continue
+		}
+		if fl[flIndex] != KnownOpenShiftFeatures[i] {
+			t.Errorf("fl[%d] == %q, but %q is right", i, fl[flIndex], KnownOpenShiftFeatures[i])
+		}
+		flIndex++
+	}
+	// delete multiple items
+	fl.Delete(KnownOpenShiftFeatures...)
+	if len(fl) != 0 {
+		t.Fatal("feature list should be empty")
+	}
+	// delete on empty list succeeds
+	fl.Delete(KnownOpenShiftFeatures[0])
+	if len(fl) != 0 {
+		t.Fatal("feature list should be empty")
+	}
+}
+
+func TestFeatureListHas(t *testing.T) {
+	fl := FeatureList{FeatureBuilder, FeatureS2I}
+	goodCases := []string{
+		"builder",
+		"BuilDer",
+		"S2I Builder",
+		"S2i builder",
+	}
+	badCases := []string{
+		"console",
+		"CONSOLE",
+		"unknown",
+		"s2ibuilder",
+	}
+	for _, gc := range goodCases {
+		if !fl.Has(gc) {
+			t.Errorf("feature list should have %q", gc)
+		}
+	}
+	for _, bc := range badCases {
+		if fl.Has(bc) {
+			t.Errorf("feature list shouldn't have %q", bc)
+		}
+	}
+}

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -73,6 +73,9 @@ const (
 	ControllersAll = "*"
 )
 
+// FeatureList contains a set of features
+type FeatureList []string
+
 type MasterConfig struct {
 	v1.TypeMeta `json:",inline"`
 
@@ -96,6 +99,11 @@ type MasterConfig struct {
 	// PauseControllers instructs the master to not automatically start controllers, but instead
 	// to wait until a notification to the server is received before launching them.
 	PauseControllers bool `json:"pauseControllers,omitempty"`
+
+	// DisabledFeatures is a list of features that should not be started.  We
+	// omitempty here because its very unlikely that anyone will want to
+	// manually disable features and we don't want to encourage it.
+	DisabledFeatures FeatureList `json:"disabledFeatures,omitempty"`
 
 	// EtcdStorageConfig contains information about how API resources are
 	// stored in Etcd. These values are only relevant when etcd is the

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -61,6 +61,8 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 		validationResults.AddErrors(urlErrs...)
 	}
 
+	validationResults.AddErrors(ValidateDisabledFeatures(config.DisabledFeatures, "disabledFeatures")...)
+
 	if config.AssetConfig != nil {
 		validationResults.AddErrors(ValidateAssetConfig(config.AssetConfig).Prefix("assetConfig")...)
 		colocated := config.AssetConfig.ServingInfo.BindAddress == config.ServingInfo.BindAddress

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -1,13 +1,16 @@
 package validation
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
 	kvalidation "github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 
 	"github.com/openshift/origin/pkg/cmd/server/api"
@@ -77,6 +80,22 @@ func ValidateHTTPServingInfo(info api.HTTPServingInfo) fielderrors.ValidationErr
 
 	if info.RequestTimeoutSeconds < -1 {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("requestTimeoutSeconds", info.RequestTimeoutSeconds, "must be -1 (no timeout), 0 (default timeout), or greater"))
+	}
+
+	return allErrs
+}
+
+func ValidateDisabledFeatures(disabledFeatures []string, field string) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	known := util.NewStringSet()
+	for _, feature := range api.KnownOpenShiftFeatures {
+		known.Insert(strings.ToLower(feature))
+	}
+	for i, feature := range disabledFeatures {
+		if _, exists := known[strings.ToLower(feature)]; !exists {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid(fmt.Sprintf("%s[%d]", field, i), disabledFeatures[i], fmt.Sprintf("not one of valid features: %s", strings.Join(api.KnownOpenShiftFeatures, ", "))))
+		}
 	}
 
 	return allErrs

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/cmd/server/admin"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/start/kubernetes"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
@@ -33,8 +34,8 @@ type AllInOneOptions struct {
 	MasterConfigFile string
 	NodeConfigFile   string
 	PrintIP          bool
-
-	Output io.Writer
+	Output           io.Writer
+	DisabledFeatures []string
 }
 
 const allInOneLong = `
@@ -61,6 +62,11 @@ You may also pass --kubeconfig=<path> to connect to an external Kubernetes clust
 // NewCommandStartAllInOne provides a CLI handler for 'start' command
 func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *AllInOneOptions) {
 	options := &AllInOneOptions{Output: out}
+
+	switch fullName {
+	case "atomic-enterprise":
+		options.DisabledFeatures = configapi.AtomicDisabledFeatures
+	}
 
 	cmds := &cobra.Command{
 		Use:   "start",
@@ -237,7 +243,7 @@ func (o AllInOneOptions) StartAllInOne() error {
 		fmt.Fprintf(o.Output, "%s\n", host)
 		return nil
 	}
-	masterOptions := MasterOptions{o.MasterArgs, o.CreateCerts, o.MasterConfigFile, o.Output}
+	masterOptions := MasterOptions{o.MasterArgs, o.CreateCerts, o.MasterConfigFile, o.Output, o.DisabledFeatures}
 	if err := masterOptions.RunMaster(); err != nil {
 		return err
 	}

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -63,8 +63,7 @@ You may also pass --kubeconfig=<path> to connect to an external Kubernetes clust
 func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *AllInOneOptions) {
 	options := &AllInOneOptions{Output: out}
 
-	switch fullName {
-	case "atomic-enterprise":
+	if cmdutil.GetProductName() == cmdutil.ProductAtomic {
 		options.DisabledFeatures = configapi.AtomicDisabledFeatures
 	}
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -69,8 +69,7 @@ You may also pass --kubeconfig=<path> to connect to an external Kubernetes clust
 func NewCommandStartMaster(fullName string, out io.Writer) (*cobra.Command, *MasterOptions) {
 	options := &MasterOptions{Output: out}
 
-	switch fullName {
-	case "atomic-enterprise":
+	if cmdutil.GetProductName() == cmdutil.ProductAtomic {
 		options.DisabledFeatures = configapi.AtomicDisabledFeatures
 	}
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -37,6 +37,7 @@ type MasterOptions struct {
 	CreateCertificates bool
 	ConfigFile         string
 	Output             io.Writer
+	DisabledFeatures   []string
 }
 
 const masterLong = `Start a master server
@@ -67,6 +68,11 @@ You may also pass --kubeconfig=<path> to connect to an external Kubernetes clust
 // NewCommandStartMaster provides a CLI handler for 'start master' command
 func NewCommandStartMaster(fullName string, out io.Writer) (*cobra.Command, *MasterOptions) {
 	options := &MasterOptions{Output: out}
+
+	switch fullName {
+	case "atomic-enterprise":
+		options.DisabledFeatures = configapi.AtomicDisabledFeatures
+	}
 
 	cmd := &cobra.Command{
 		Use:   "master",
@@ -245,6 +251,10 @@ func (o MasterOptions) RunMaster() error {
 		return nil
 	}
 
+	// Inject disabled feature flags based on distribution being used and
+	// regardless of configuration. They aren't written to config file to
+	// prevent upgrade path issues.
+	masterConfig.DisabledFeatures.Add(o.DisabledFeatures...)
 	validationResults := validation.ValidateMasterConfig(masterConfig)
 	if len(validationResults.Warnings) != 0 {
 		for _, warning := range validationResults.Warnings {
@@ -307,6 +317,9 @@ func (o MasterOptions) CreateCerts() error {
 func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	glog.Infof("Starting master on %s (%s)", openshiftMasterConfig.ServingInfo.BindAddress, version.Get().String())
 	glog.Infof("Public master address is %s", openshiftMasterConfig.AssetConfig.MasterPublicURL)
+	if glog.V(4) && len(openshiftMasterConfig.DisabledFeatures) > 0 {
+		glog.Infof("Disabled features: %s", strings.Join(openshiftMasterConfig.DisabledFeatures, ", "))
+	}
 
 	if openshiftMasterConfig.EtcdConfig != nil {
 		etcd.RunEtcd(openshiftMasterConfig.EtcdConfig)

--- a/pkg/cmd/util/product.go
+++ b/pkg/cmd/util/product.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"github.com/kardianos/osext"
+)
+
+const (
+	ProductOrigin    = `Origin`
+	ProductOpenShift = `OpenShift`
+	ProductAtomic    = `Atomic`
+)
+
+// GetProductName chooses appropriate product for a real path of current
+// executable.
+func GetProductName() string {
+	path, err := osext.Executable()
+	if err != nil {
+		glog.Warning("Failed to get absolute binary path: %v", err)
+		path = os.Args[0]
+	}
+	name := filepath.Base(path)
+	for {
+		switch name {
+		case "openshift":
+			return ProductOpenShift
+		case "atomic-enterprise":
+			return ProductAtomic
+		default:
+			return ProductOrigin
+		}
+	}
+}


### PR DESCRIPTION
Resolve symlinks to the real binary path and use its name to choose correct
product. This handles symlinks like oc, oadm, etc.

Extends #3953
